### PR TITLE
Refact/webpack upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the options:
 ## Usage with webpack
 
 The module come with a webpack plugin.
+In this case, files will be readed/writed through the webpack compilation assets.
 
 ```javascript
 const { HomemadeDTSBundlerPlugin } = require("homemade-dts-bundler");

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "homemade-dts-bundler",
   "version": "0.2.0",
   "description": "Homemade dts bundler. Not much options but should handle module merging. Webpack plugin inside.",
+  "keywords": ["typescript", "dts", ".d.ts", "bundler", "webpack"],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -29,7 +30,7 @@
     "url": "https://github.com/Waidd/homemade-dts-bundler"
   },
   "engines": {
-    "node" : ">=8.11.3"
+    "node": ">=8.11.3"
   },
   "license": "Unlicense",
   "author": "Thomas Cholley <cholley.t@gmail.com>"

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,9 +1,8 @@
-import { promisify } from "util";
-import * as fs from "fs";
-const writeFile = promisify(fs.writeFile);
+import * as  webpack from "webpack";
 
 import { IDTSOptions } from "./options";
 import { TreeExplorer } from "./treeExplorer";
+import { AFileInterface, FileInterfaceFilesystem, FileInterfaceWebpack } from "./fileInterfaces";
 
 /**
  * Bundle declaration files from tsc output to a single file using the options.
@@ -15,20 +14,34 @@ export class Bundler {
 	 * @returns a promise resolved when the file is writed.
 	 */
 	public static async bundle(options: IDTSOptions): Promise<void> {
-		const bundler = new Bundler(options);
+		const bundler = new Bundler(options, new FileInterfaceFilesystem());
+		await bundler.bundle();
+	}
+
+	/**
+	 * This function handle the whole process throught a webpack compilation.
+	 * @param options Bundling options as specified in IDTSOptions.
+	 * @param compilation Webpack compilation.
+	 * @returns a promise resolved when the file is writed in the compilation assets.
+	 */
+	public static async bundleWithWebpack(options: IDTSOptions, compilation: webpack.compilation.Compilation) {
+		const bundler = new Bundler(options, new FileInterfaceWebpack(compilation));
 		await bundler.bundle();
 	}
 
 	private _options: IDTSOptions;
+	private _fileInterface: AFileInterface;
 	private _treeExplorer: TreeExplorer;
 
 	/**
 	 * Bundle constructor.
 	 * @param options Bundling options as specified in IDTSOptions.
+	 * @param fileInterface fileInterface to handle file I/O.
 	 */
-	public constructor(options: IDTSOptions) {
+	public constructor(options: IDTSOptions, fileInterface: AFileInterface) {
 		this._options = options;
-		this._treeExplorer = new TreeExplorer(options);
+		this._fileInterface = fileInterface;
+		this._treeExplorer = new TreeExplorer(options, fileInterface);
 	}
 
 	/**
@@ -38,6 +51,6 @@ export class Bundler {
 	public async bundle(): Promise<void> {
 		const files = await this._treeExplorer.explore();
 		const content = files.map((file) => file.content).join("\n");
-		await writeFile(this._options.output, content);
+		await this._fileInterface.writeFile(this._options.output, content);
 	}
 }

--- a/src/fileInterfaces/fileInterface.ts
+++ b/src/fileInterfaces/fileInterface.ts
@@ -1,0 +1,26 @@
+/**
+ * Interface to read & write files.
+ */
+export abstract class AFileInterface {
+	/**
+	 * Read file & returns content.
+	 * @param absolutePath absolute path of the file.
+	 * @returns content of the file.
+	 */
+	public abstract async readFile(absolutePath: string): Promise<string>;
+
+	/**
+	 * Check if file exists.
+	 * @param absolutePath absolute path of the file.
+	 * @returns true if it exists nor false.
+	 */
+	public abstract async exists(absolutePath: string): Promise<boolean>;
+
+	/**
+	 * Write file.
+	 * @param absolutePath absolute path of the file.
+	 * @param content content to write in the file.
+	 * @returns a promise resolved when the file is writed.
+	 */
+	public abstract async writeFile(absolutePath: string, content: string): Promise<void>;
+}

--- a/src/fileInterfaces/fileInterfaceFilesystem.ts
+++ b/src/fileInterfaces/fileInterfaceFilesystem.ts
@@ -1,0 +1,46 @@
+import * as fs from "fs";
+import { promisify } from "util";
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+const stat = promisify(fs.stat);
+
+import { AFileInterface } from "./fileInterface";
+
+/**
+ * Interface to read & write files throught the filesystem.
+ */
+export class FileInterfaceFilesystem extends AFileInterface {
+	/**
+	 * Read file from the filesystem & returns content.
+	 * @param absolutePath absolute path of the file.
+	 * @returns content of the file.
+	 */
+	public async readFile(absolutePath: string): Promise<string> {
+		return (await readFile(absolutePath)).toString();
+	}
+
+	/**
+	 * Check if file exists on the filesystem.
+	 * @param absolutePath asbolute path of the file.
+	 * @returns true if it exists nor false.
+	 */
+	public async exists(absolutePath: string): Promise<boolean> {
+		try {
+			await stat(absolutePath);
+			return true;
+		} catch (up) {
+			if (up.code !== "ENOENT") { throw up; }
+		}
+		return false;
+	}
+
+	/**
+	 * Write file to the filesystem.
+	 * @param absolutePath absolute path of the file.
+	 * @param content content to write in the file.
+	 * @returns a promise resolved when the file is writed.
+	 */
+	public async writeFile(absolutePath: string, content: string): Promise<void> {
+		await writeFile(absolutePath, content);
+	}
+}

--- a/src/fileInterfaces/fileInterfaceWebpack.ts
+++ b/src/fileInterfaces/fileInterfaceWebpack.ts
@@ -1,0 +1,61 @@
+import * as webpack from "webpack";
+import { resolve } from "path";
+
+import { AFileInterface } from "./fileInterface";
+
+/**
+ * Interface to read & write files throught webpack compilation.
+ */
+export class FileInterfaceWebpack extends AFileInterface {
+	private _compilation: webpack.compilation.Compilation;
+
+	/**
+	 * Constructor of the interface.
+	 * @param compilation webpack compilation to read/write from.
+	 */
+	public constructor(compilation: webpack.compilation.Compilation) {
+		super();
+		this._compilation = compilation;
+	}
+
+	/**
+	 * Read file in the assets of the webpack compilation.
+	 * @param absolutePath absolute path of the file.
+	 * @returns content of the file.
+	 */
+	public async readFile(absolutePath: string): Promise<string> {
+		const relativePath = this._getRelativePath(absolutePath);
+		return this._compilation.assets[relativePath].source();
+	}
+
+	/**
+	 * Check if file exists in the assets of the webpack compilation.
+	 * @param absolutePath absolute path of the file.
+	 * @returns true if it exists nor false.
+	 */
+	public async exists(absolutePath: string): Promise<boolean> {
+		const relativePath = this._getRelativePath(absolutePath);
+
+		return this._compilation.assets[relativePath] !== undefined;
+	}
+
+	/**
+	 * Write file in an asset of the webpack compilation.
+	 * @param absolutePath absolute path of the file.
+	 * @param content content to write in the file.
+	 * @returns a promise resolved when the file is added to the compilation assets.
+	 */
+	public async writeFile(absolutePath: string, content: string): Promise<void> {
+		const relativePath = this._getRelativePath(absolutePath);
+
+		this._compilation.assets[relativePath] = {
+			source: () => new Buffer(content),
+			size: () => Buffer.byteLength(content),
+		};
+	}
+
+	private _getRelativePath(absolutePath: string): string {
+		const basePath = resolve(this._compilation.compiler.options.output.path);
+		return absolutePath.replace(`${basePath}/`, "");
+	}
+}

--- a/src/fileInterfaces/index.ts
+++ b/src/fileInterfaces/index.ts
@@ -1,0 +1,3 @@
+export * from "./fileInterface";
+export * from "./fileInterfaceFilesystem";
+export * from "./fileInterfaceWebpack";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./bundler";
 export * from "./treeExplorer";
 export * from "./fileHandler";
+export * from "./fileInterfaces";
 export * from "./options";
 export * from "./webpackPlugin";

--- a/src/treeExplorer.ts
+++ b/src/treeExplorer.ts
@@ -1,5 +1,6 @@
 import { IDTSOptions } from "./options";
 import { FileHandler, IDeclarationObject } from "./fileHandler";
+import { AFileInterface } from "./fileInterfaces/fileInterface";
 
 type DeclarationTree = Promise<IDeclarationObject[]>;
 
@@ -13,10 +14,11 @@ export class TreeExplorer {
 	/**
 	 * TreeExplorer constructor.
 	 * @param options Bundling options as specified in IDTSOptions
+	 * @param fileInterface fileInterface to handle file I/O.
 	 */
-	public constructor(options: IDTSOptions) {
+	public constructor(options: IDTSOptions, fileInterface: AFileInterface) {
 		this._options = options;
-		this._fileHandler = new FileHandler(options);
+		this._fileHandler = new FileHandler(options, fileInterface);
 	}
 
 	/**

--- a/src/webpackPlugin.ts
+++ b/src/webpackPlugin.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path";
-import webpack = require("webpack");
+import * as webpack from "webpack";
 
 import { IDTSOptions } from "./options";
 import { Bundler } from "./bundler";
@@ -28,11 +28,11 @@ export class HomemadeDTSBundlerPlugin {
 	 * @param compiler webpack compiler.
 	 */
 	public apply(compiler: webpack.Compiler) {
-		compiler.hooks.done.tapPromise("homemadeDTSBundler", async (compilation: webpack.Stats) => {
+		compiler.hooks.emit.tapPromise("homemadeDTSBundler", async (compilation: webpack.compilation.Compilation) => {
 			try {
-				await Bundler.bundle(this._options);
+				await Bundler.bundleWithWebpack(this._options, compilation);
 			} catch (e) {
-				compilation.compilation.errors.push(new Error(`homemade-dts-bundler:\n\t${e.message}`));
+				compilation.errors.push(new Error(`homemade-dts-bundler:\n\t${e.message}`));
 			}
 		});
 	}

--- a/src/webpackPlugin.ts
+++ b/src/webpackPlugin.ts
@@ -28,6 +28,12 @@ export class HomemadeDTSBundlerPlugin {
 	 * @param compiler webpack compiler.
 	 */
 	public apply(compiler: webpack.Compiler) {
-		compiler.hooks.done.tapPromise("homemadeDTSBundler", () => Bundler.bundle(this._options));
+		compiler.hooks.done.tapPromise("homemadeDTSBundler", async (compilation: webpack.Stats) => {
+			try {
+				await Bundler.bundle(this._options);
+			} catch (e) {
+				compilation.compilation.errors.push(new Error(`homemade-dts-bundler:\n\t${e.message}`));
+			}
+		});
 	}
 }


### PR DESCRIPTION
Properly catch error to avoid breaking webpack compilation.
When using webpack, read/write files from compilation assets instead of using directly the file system.